### PR TITLE
container style fix

### DIFF
--- a/App/src/components/schedule/schedule.tsx
+++ b/App/src/components/schedule/schedule.tsx
@@ -48,7 +48,7 @@ export const Schedule = () => {
 	}, [gamesQuerySnapshot])
 
 	return (
-		<div className={'sm:container'}>
+		<div className="container">
 			<GradientHeader>Schedule</GradientHeader>
 
 			{!gamesQuerySnapshot ? (


### PR DESCRIPTION
## Changes

The Schedule page did not have the same padding on mobile as the Standings page. Changing the classname on the parent div from `sm:container` to `container` like on the Standings page fixes this.

| Coming soon before | Coming soon after |
|--------|-------|
| <img width="369" height="794" alt="Screenshot 2025-09-22 at 10 45 44 AM" src="https://github.com/user-attachments/assets/0d5ade80-d19d-4f94-8b3c-b3457229e81c" /> | <img width="367" height="793" alt="Screenshot 2025-09-22 at 10 46 12 AM" src="https://github.com/user-attachments/assets/41e7eaca-0dac-47ab-85fc-737281f86580" /> |

| Schedule before | Schedule fter |
|--------|-------|
| <img width="367" height="793" alt="Screenshot 2025-09-22 at 10 45 12 AM" src="https://github.com/user-attachments/assets/bc3750fa-8881-42c1-b819-b2f63c57a24f" /> | <img width="369" height="794" alt="Screenshot 2025-09-22 at 10 46 46 AM" src="https://github.com/user-attachments/assets/4998e076-f767-433e-ad64-4a560fd89901" /> |